### PR TITLE
Move account icon to topbar for logo-left header

### DIFF
--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -397,10 +397,6 @@
                                     render 'country-selector', box_size: 'hidden xl:block'
                                   endif
 
-                                  if show_account_icon
-                                    render 'header-option-item__account', display_by: 'icon'
-                                  endif
-
                                   if show_wishlist_icon
                                     render 'header-option-item__wishlist', display_by: 'icon'
                                   endif

--- a/snippets/header__topbar.liquid
+++ b/snippets/header__topbar.liquid
@@ -25,16 +25,7 @@
           <div class="flex items-center w-1/3">
             {% if show_phone_numb %}
               <a href="tel:{{ settings.contact_phone_number }}" class="flex items-center px-4">
-                <svg
-                  class="w-[16px] h-[16px]"
-                  fill="currentColor"
-                  stroke="currentColor"
-                  xmlns="http://www.w3.org/2000/svg"
-                  viewBox="0 0 512 512"
-                >
-                  <path fill="currentColor" d="M493.09 351.3L384.7 304.8a31.36 31.36 0 0 0-36.5 8.9l-44.1 53.9A350 350 0 0 1 144.5 208l53.9-44.1a31.35 31.35 0 0 0 8.9-36.49l-46.5-108.5A31.33 31.33 0 0 0 125 .81L24.2 24.11A31.05 31.05 0 0 0 0 54.51C0 307.8 205.3 512 457.49 512A31.23 31.23 0 0 0 488 487.7L511.19 387a31.21 31.21 0 0 0-18.1-35.7zM456.89 480C222.4 479.7 32.3 289.7 32.1 55.21l99.6-23 46 107.39-72.8 59.5C153.3 302.3 209.4 358.6 313 407.2l59.5-72.8 107.39 46z" class=""></path>
-                </svg>
-                <span class="ml-2">{{ settings.contact_phone_number }}</span>
+                <span>{{ settings.contact_phone_number }}</span>
               </a>
             {% endif %}
             {% if show_email %}
@@ -59,6 +50,9 @@
             <div class="flex items-center w-1/3 justify-center">{{ message }}</div>
           {% endif %}
           <div class="w-1/3 flex items-center justify-end">
+            {% if header.settings.header_design == 'logo-left__2l' and header.settings.show_account_icon %}
+              {% render 'header-option-item__account', display_by: 'icon' %}
+            {% endif %}
             {% if show_stores_page %}
               <a
                 href="{{ pages[settings.find_store].url | default: '#' }}"


### PR DESCRIPTION
## Summary
- show account icon in topbar right area when header design is `logo-left__2l`
- remove account icon from main header for this design to avoid duplication
- drop telephone SVG so topbar shows plain phone number

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68928d5e0314832da9888211357a6d5f