### PR TITLE
Refactor collection double quantity to use delegation and observe layout

### DIFF
--- a/assets/double-qty.js
+++ b/assets/double-qty.js
@@ -268,8 +268,7 @@ var BUTTON_CLASS = 'double-qty-btn';
   }
 
   function initDoubleQtyButtons() {
-    document.querySelectorAll('.' + BUTTON_CLASS).forEach(function(btn){
-      if (btn.hasAttribute('data-collection-double-qty') || btn.classList.contains('collection-double-qty-btn')) return;
+    document.querySelectorAll('.' + BUTTON_CLASS + ':not([data-collection-double-qty])').forEach(function(btn){
       var input = findQtyInput(btn);
       if (!input) return;
       var storedMin = parseInt(btn.getAttribute('data-original-min-qty'), 10);


### PR DESCRIPTION
## Summary
- refactor collection quick-add to bind double quantity via delegated events
- add MutationObserver so layout updates for dynamically inserted cards
- limit classic double-qty script to ignore collection buttons

## Testing
- `node --check assets/collection-quick-add.js`
- `node --check assets/double-qty.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6893b1fc49e4832da2b188481bead009