### PR TITLE
refactor: robust collection double qty delegation

### DIFF
--- a/assets/double-qty.js
+++ b/assets/double-qty.js
@@ -269,7 +269,7 @@ var BUTTON_CLASS = 'double-qty-btn';
 
   function initDoubleQtyButtons() {
     document.querySelectorAll('.' + BUTTON_CLASS).forEach(function(btn){
-      if (btn.hasAttribute('data-collection-double-qty') || btn.classList.contains('collection-double-qty-btn')) return;
+      if (btn.hasAttribute('data-collection-double-qty')) return;
       var input = findQtyInput(btn);
       if (!input) return;
       var storedMin = parseInt(btn.getAttribute('data-original-min-qty'), 10);


### PR DESCRIPTION
## Summary
- use delegated events for `.collection-double-qty-btn` and quantity inputs
- add MutationObserver to refresh collection quantity groups on dynamic DOM updates
- drop redundant collection button handling from `double-qty.js`

## Testing
- `node --check assets/collection-quick-add.js`
- `node --check assets/double-qty.js`
- `npm test` *(fails: Could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_6893b4ae5ad4832db2468b597ca6185c